### PR TITLE
adopt previous changes to templates from FIO-7030

### DIFF
--- a/src/templates/bootstrap4/builderWizard/form.ejs
+++ b/src/templates/bootstrap4/builderWizard/form.ejs
@@ -3,20 +3,18 @@
     {{ctx.sidebar}}
   </div>
   <div class="col-xs-8 col-sm-9 col-md-10 formarea">
-    <div class="breadcrumb wizard-page-container">
-      <ol class="wizard-pages">
+    <ol class="breadcrumb wizard-pages">
         {% ctx.pages.forEach(function(page, pageIndex) { %}
           <li id="{{page.key}}">
             <span title="{{page.title}}" class="mr-2 badge {% if (pageIndex === ctx.self.page) { %}badge-primary{% } else { %}badge-info{% } %} wizard-page-label" ref="gotoPage">{{page.title}}</span>
           </li>
         {% }) %}
+          <li class="wizard-add-page">
+            <span title="{{ctx.t('Create Page')}}" class="mr-2 badge badge-success wizard-page-label" ref="addPage">
+              <i class="{{ctx.iconClass('plus')}}"></i> {{ctx.t('Page')}}
+            </span>
+          </li>
       </ol>
-      <div class="wizard-add-page">
-        <span title="{{ctx.t('Create Page')}}" class="mr-2 badge badge-success wizard-page-label" ref="addPage">
-          <i class="{{ctx.iconClass('plus')}}"></i> {{ctx.t('Page')}}
-        </span>
-      </div>
-    </div>
     <div ref="form">
       {{ctx.form}}
     </div>

--- a/src/templates/bootstrap5/builderWizard/form.ejs
+++ b/src/templates/bootstrap5/builderWizard/form.ejs
@@ -3,20 +3,18 @@
     {{ctx.sidebar}}
   </div>
   <div class="col-xs-8 col-sm-9 col-md-10 formarea">
-    <div class="breadcrumb wizard-page-container">
-      <ol class="wizard-pages">
-        {% ctx.pages.forEach(function(page, pageIndex) { %}
-          <li id="{{page.key}}">
-            <span title="{{page.title}}" class="mr-2 badge {% if (pageIndex === ctx.self.page) { %}badge-primary{% } else { %}badge-info{% } %} wizard-page-label" ref="gotoPage">{{page.title}}</span>
-          </li>
-        {% }) %}
-      </ol>
-      <div class="wizard-add-page">
-        <span title="{{ctx.t('Create Page')}}" class="mr-2 badge badge-success wizard-page-label" ref="addPage">
+    <ol class="breadcrumb wizard-pages">
+      {% ctx.pages.forEach(function(page, pageIndex) { %}
+      <li>
+        <span title="{{page.title}}" class="me-2 badge {% if (pageIndex === ctx.self.page) { %}bg-primary{% } else { %}bg-info{% } %} wizard-page-label" ref="gotoPage">{{page.title}}</span>
+      </li>
+      {% }) %}
+      <li class="wizard-add-page">
+        <span title="{{ctx.t('Create Page')}}" class="me-2 badge bg-success wizard-page-label" ref="addPage">
           <i class="{{ctx.iconClass('plus')}}"></i> {{ctx.t('Page')}}
         </span>
-      </div>
-    </div>
+      </li>
+    </ol>
     <div ref="form">
       {{ctx.form}}
     </div>


### PR DESCRIPTION
These templates were spun off from formio.js during the process of moving that repository to bootstrap 5 and typescript. Between the time that that branch spun these off and now, developers have made certain changes to the templates. This PR catches us up for the changes made in FIO-7030.