### PR TITLE
FIO-7209 Radio works without ValueProperty set

### DIFF
--- a/src/templates/bootstrap3/radio/form.ejs
+++ b/src/templates/bootstrap3/radio/form.ejs
@@ -1,7 +1,7 @@
 <div class="input-group">
-  {% ctx.values.forEach(function(item) { %}
+  {% ctx.values.forEach(function(item, index) { %}
   <div class="{{ctx.input.attr.type}}{{ctx.inline ? '-inline' : ''}}" ref="wrapper">
-    <label class="control-label form-check-label label-position-{{ ctx.component.optionsLabelPosition }}" for="{{ctx.instance.root && ctx.instance.root.id}}-{{ctx.id}}-{{ctx.row}}-{{item.value}}">
+    <label class="control-label form-check-label label-position-{{ ctx.component.optionsLabelPosition }}" for="{{ctx.instance.root && ctx.instance.root.id}}-{{ctx.id}}-{{ctx.row}}-{{(typeof item.value === 'object') ? item.value + '-' + index : item.value}}">
       {% if (ctx.component.optionsLabelPosition === 'left' || ctx.component.optionsLabelPosition === 'top') { %}
       <span>{{ctx.t(item.label, { _userInput: true })}}</span>
       {% } %}
@@ -17,7 +17,7 @@
         {% if (item.disabled) { %}
           disabled=true
         {% } %}
-        id="{{ctx.instance.root && ctx.instance.root.id}}-{{ctx.id}}-{{ctx.row}}-{{item.value}}"
+        id="{{ctx.instance.root && ctx.instance.root.id}}-{{ctx.id}}-{{ctx.row}}-{{(typeof item.value === 'object') ? item.value + '-' + index : item.value}}"
       >
       {% if (!ctx.component.optionsLabelPosition || ctx.component.optionsLabelPosition === 'right' || ctx.component.optionsLabelPosition === 'bottom') { %}
       <span>{{ctx.t(item.label, { _userInput: true })}}</span>

--- a/src/templates/bootstrap4/radio/form.ejs
+++ b/src/templates/bootstrap4/radio/form.ejs
@@ -8,9 +8,9 @@
     aria-describedby="d-{{ctx.instance.id}}-{{ctx.component.key}}"
   {% } %}
 >
-  {% ctx.values.forEach(function(item) { %}
+  {% ctx.values.forEach(function(item, index) { %}
   <div class="{{ctx.input.attr.type}} {{ ctx.component.optionsLabelPosition && ctx.component.optionsLabelPosition !== 'right' ? 'pl-0' : ''}} form-check{{ctx.inline ? '-inline' : ''}}" ref="wrapper">
-    <label class="form-check-label label-position-{{ ctx.component.optionsLabelPosition }}" for="{{ctx.instance.root && ctx.instance.root.id}}-{{ctx.id}}-{{ctx.row}}-{{item.value}}">
+    <label class="form-check-label label-position-{{ ctx.component.optionsLabelPosition }}" for="{{ctx.instance.root && ctx.instance.root.id}}-{{ctx.id}}-{{ctx.row}}-{{(typeof item.value === 'object') ? item.value + '-' + index : item.value}}">
       {% if (ctx.component.optionsLabelPosition === 'left' || ctx.component.optionsLabelPosition === 'top') { %}
       <span>{{ctx.t(item.label, { _userInput: true })}}</span>
       {% } %}
@@ -26,7 +26,7 @@
         {% if (item.disabled) { %}
           disabled=true
         {% } %}
-        id="{{ctx.instance.root && ctx.instance.root.id}}-{{ctx.id}}-{{ctx.row}}-{{item.value}}"
+        id="{{ctx.instance.root && ctx.instance.root.id}}-{{ctx.id}}-{{ctx.row}}-{{(typeof item.value === 'object') ? item.value + '-' + index : item.value}}"
         role="{{ctx.component.type === 'selectboxes' ? 'checkbox' : 'radio'}}"
       >
       {% if (!ctx.component.optionsLabelPosition || ctx.component.optionsLabelPosition === 'right' || ctx.component.optionsLabelPosition === 'bottom') { %}

--- a/src/templates/bootstrap5/radio/form.ejs
+++ b/src/templates/bootstrap5/radio/form.ejs
@@ -8,10 +8,10 @@
     aria-describedby="d-{{ctx.instance.id}}-{{ctx.component.key}}"
   {% } %}
 >
-  {% ctx.values.forEach(function(item) { %}
+  {% ctx.values.forEach(function(item, index) { %}
   <div class="{{ctx.input.attr.type}} {{ ctx.component.optionsLabelPosition && ctx.component.optionsLabelPosition !== 'right' ? 'ps-0' : ''}} form-check{{ctx.inline ? '-inline' : ''}}" ref="wrapper">
     {% if (['left', 'top'].includes(ctx.component.optionsLabelPosition)) { %}
-    <label class="form-check-label label-position-{{ ctx.component.optionsLabelPosition }}" for="{{ctx.instance.root && ctx.instance.root.id}}-{{ctx.id}}-{{ctx.row}}-{{item.value}}"><span>{{ctx.t(item.label, { _userInput: true })}}</span></label>
+    <label class="form-check-label label-position-{{ ctx.component.optionsLabelPosition }}" for="{{ctx.instance.root && ctx.instance.root.id}}-{{ctx.id}}-{{ctx.row}}-{{(typeof item.value === 'object') ? item.value + '-' + index : item.value}}"><span>{{ctx.t(item.label, { _userInput: true })}}</span></label>
     {% } %}
     <{{ctx.input.type}}
         ref="input"
@@ -25,11 +25,11 @@
         {% if (item.disabled) { %}
           disabled=true
         {% } %}
-        id="{{ctx.instance.root && ctx.instance.root.id}}-{{ctx.id}}-{{ctx.row}}-{{item.value}}"
+        id="{{ctx.instance.root && ctx.instance.root.id}}-{{ctx.id}}-{{ctx.row}}-{{(typeof item.value === 'object') ? item.value + '-' + index : item.value}}"
         role="{{ctx.component.type === 'selectboxes' ? 'checkbox' : 'radio'}}"
       >
     {% if (!ctx.component.optionsLabelPosition || ['right', 'bottom'].includes(ctx.component.optionsLabelPosition)) { %}
-    <label class="form-check-label label-position-{{ ctx.component.optionsLabelPosition }}" for="{{ctx.instance.root && ctx.instance.root.id}}-{{ctx.id}}-{{ctx.row}}-{{item.value}}"><span>{{ctx.t(item.label, { _userInput: true })}}</span></label>
+    <label class="form-check-label label-position-{{ ctx.component.optionsLabelPosition }}" for="{{ctx.instance.root && ctx.instance.root.id}}-{{ctx.id}}-{{ctx.row}}-{{(typeof item.value === 'object') ? item.value + '-' + index : item.value}}"><span>{{ctx.t(item.label, { _userInput: true })}}</span></label>
     {% } %}
   </div>
   {% }) %}


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7209

## Description

*If Value Property doesn't set for Radio Component with DataSrc url, the User will be able to submit the form. The item itself is used as value property. Previously, if the value had the Object type, then when clicking on the item label, an inappropriate value was selected. This issue has been fixed. Now when User clicks on the option label, the corresponding value for the Radio component is selected*

## Dependencies

*https://github.com/formio/formio.js/pull/5310*

