### PR TITLE
Bootstrap5: Missing icons for panel collapse/uncollapse

### DIFF
--- a/src/templates/bootstrap5/iconClass.ts
+++ b/src/templates/bootstrap5/iconClass.ts
@@ -25,6 +25,12 @@ export default (iconset, name, spinning) => {
         case 'dot-circle-o':
             biName = 'ui-radios';
             break;
+        case 'plus-square-o':
+            biName = 'plus-square';
+            break;
+        case 'minus-square-o':
+            biName = 'dash-square';
+            break;                    
         case 'plus-square':
             biName = 'ui-checks';
             break;


### PR DESCRIPTION
Hi Formio Team,

please can merge this pull request to add the icons for panel collapse/uncollapse.

Best regard

Ralf