### PR TITLE
FIO-8234/FIO-7195: Fixes an issue where value properties are shown instead of labels for Select component with Resource/URL data sources in DataTable

### DIFF
--- a/lib/mjs/package.json
+++ b/lib/mjs/package.json
@@ -1,3 +1,0 @@
-{
-    "type": "module"
-}

--- a/src/templates/bootstrap4/tbody/html.ejs
+++ b/src/templates/bootstrap4/tbody/html.ejs
@@ -9,10 +9,10 @@
       {% } %}
     {% row.forEach(function(rowComp) { %}
       {% if (rowComp.component.show) { %}
-      <td 
+      <td
         {{ ctx.component.cellMaxWidth ? 'style="max-width:'+ ctx.component.cellMaxWidth + ';"' : ''}}
         {{ ctx.component.clipCells ? 'class="clip"' : ''}}>
-          {{ ctx.instance.hook('format', rowComp.component.key, rowComp.dataValue) }}
+          {{ ctx.instance.hook('format', rowComp.component.key, rowComp.dataValue, rowComp.rowIndex) }}
       </td>
       {% } %}
     {% }); %}


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8234
https://formio.atlassian.net/browse/FIO-7195

## Description

Need to pass a rowindex to the format hook in DataTable, so it can pass the correspondent selectMetadata to the instance and render the label properly

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
