### PR TITLE
FIO-9169 Changed fontawesome name of move icon

### DIFF
--- a/src/templates/bootstrap5/builderComponent/form.ejs
+++ b/src/templates/bootstrap5/builderComponent/form.ejs
@@ -46,7 +46,7 @@
         class="btn btn-xxs btn-default component-settings-button component-settings-button-move"
         ref="moveComponent"
       >
-        <i class="{{ctx.iconClass('arrows')}}"></i>
+        <i class="{{ctx.iconClass('move')}}"></i>
       </div>
       {% if (!(ctx.design && ctx.childComponent.type === 'reviewpage')) { %}
         <div

--- a/src/templates/bootstrap5/iconClass.ts
+++ b/src/templates/bootstrap5/iconClass.ts
@@ -112,7 +112,8 @@ export default (iconset, name, spinning) => {
         case 'new-window':
             biName = 'window-plus';
             break;
-        case 'arrows':
+        case 'move':
+            name = 'arrows';
             biName = 'arrows-move';
             break;
         case 'edit':


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9169

## Description

Reverted my previous change of iconClass name for 'Move' button, and added a default value in the case fontawesome is still used, so that the change is reverse compatible for every other template.

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

Tested locally

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
