### PR TITLE
add inline styling for select component height

### DIFF
--- a/src/templates/bootstrap5/select/form.ejs
+++ b/src/templates/bootstrap5/select/form.ejs
@@ -20,4 +20,5 @@
        {% } %}
        tabindex="-1"
        aria-label="{{ctx.t('autocomplete')}}"
+       style="height:calc(1.4em + 0.75rem + 2px);"
 />


### PR DESCRIPTION
## Link to Jira Ticket

n/a

## Description

It looks like Bootstrap 5 eliminated static height declaration for the `form-control` class, which caused select comps to appear ultra thin. This PR inlines that style to the template.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
