### PR TITLE
FIO-9245 DataGrid: Fix width and positioning for table buttons

### DIFF
--- a/src/templates/bootstrap4/datagrid/form.ejs
+++ b/src/templates/bootstrap4/datagrid/form.ejs
@@ -38,8 +38,8 @@
     {% } %}
     <tr ref="{{ctx.datagridKey}}-row">
       {% if (ctx.component.reorder) { %}
-        <td class="col-1">
-          <button type="button" class="formio-drag-button btn btn-default fa fa-bars" data-key="{{ctx.datagridKey}}"></button>
+        <td>
+          <button type="button" class="formio-drag-button btn btn-default fa fa-bars" data-key="{{ctx.datagridKey}}" style="display: block; margin: 0 auto"></button>
         </td>
       {% } %}
       {% ctx.columns.forEach(function(col) { %}
@@ -49,8 +49,8 @@
       {% }) %}
       {% if (ctx.hasExtraColumn) { %}
         {% if (ctx.hasRemoveButtons) { %}
-        <td class="col-1">
-          <button type="button" class="btn btn-secondary formio-button-remove-row" ref="{{ctx.datagridKey}}-removeRow" tabindex="{{ctx.tabIndex}}" aria-label="{{ctx.t('remove')}}">
+        <td>
+          <button type="button" class="btn btn-secondary formio-button-remove-row" ref="{{ctx.datagridKey}}-removeRow" tabindex="{{ctx.tabIndex}}" aria-label="{{ctx.t('remove')}}" style="display: block; margin: 0 auto">
             <i class="{{ctx.iconClass('remove-circle')}}"></i>
           </button>
         </td>

--- a/src/templates/bootstrap5/datagrid/form.ejs
+++ b/src/templates/bootstrap5/datagrid/form.ejs
@@ -38,8 +38,8 @@
     {% } %}
     <tr ref="{{ctx.datagridKey}}-row">
       {% if (ctx.component.reorder) { %}
-        <td class="col-1">
-          <button type="button" class="formio-drag-button btn btn-default bi bi-list" data-key="{{ctx.datagridKey}}"></button>
+        <td>
+          <button type="button" class="formio-drag-button btn btn-default bi bi-list" data-key="{{ctx.datagridKey}}" style="display: block; margin: 0 auto"></button>
         </td>
       {% } %}
       {% ctx.columns.forEach(function(col) { %}
@@ -49,8 +49,8 @@
       {% }) %}
       {% if (ctx.hasExtraColumn) { %}
         {% if (ctx.hasRemoveButtons) { %}
-        <td class="col-1">
-          <button type="button" class="btn btn-secondary formio-button-remove-row" ref="{{ctx.datagridKey}}-removeRow" tabindex="{{ctx.tabIndex}}" aria-label="{{ctx.t('remove')}}">
+        <td>
+          <button type="button" class="btn btn-secondary formio-button-remove-row" ref="{{ctx.datagridKey}}-removeRow" tabindex="{{ctx.tabIndex}}" aria-label="{{ctx.t('remove')}}" style="display: block; margin: 0 auto">
             <i class="{{ctx.iconClass('remove-circle')}}"></i>
           </button>
         </td>


### PR DESCRIPTION
- Remove col-1 bootstrap class, which causes the button to expand to a large width in certain cases
- Reverts https://github.com/formio/bootstrap/commit/3dde49ae769c569d9dec5e0a2126ab47359717ab#diff-d4f4129fd92b63c9446af2cf9a7d3d15b45cfbfc8b7adb61b131e5c8c1227bdf

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9245

## Description

**What changed?**

Removed `col-1` bootstrap class from the data grid table buttons, which takes 1/12 of the width of the grid row. In certain cases, when using Safari (and I _think_ in certain cases when making the screen size smaller) the width of this button would expand dramatically and squash the other rows. I also removed the class from the data grid reorder button since the same problem could occur there. I also added `display: block` and `margin: 0 auto` to the buttons to center them in their table cells for a more consistent layout.

**Why have you chosen this solution?**

It seemed to me that a similar bootstrap class `col-md-1` (which also takes up 1/12 of the grid row, but is applied at a breakpoint of screens sized  >= 768px) was added in the bootstrap3 data grid template [here](https://github.com/formio/bootstrap/pull/53/files) and then copy/pasted to the bootstrap4 template. It was later modified to `col-1` in bootstrap 4 [here](https://github.com/formio/bootstrap/commit/3dde49ae769c569d9dec5e0a2126ab47359717ab) and `col-1` was **added** in bootstrap5. However, while fixing the problem in most cases, it was still broken in Safari; I'm guessing that Safari is calculating the parent grid container differently somehow, so that 1/12 of its width is massive compared to the other items. 

That change stemmed from this ticket https://formio.atlassian.net/browse/FIO-8303. 

Here's a video demonstrating the fix in a few different environments (on Safari, with Form Manager, which uses bootstrap 4 still and on FVP). I was having trouble getting FVP to load in the @formio/bootstrap changes, so I apply them manually in the recording. 

https://github.com/user-attachments/assets/3e025829-c3d4-4ef6-b755-98191c2e84cd

## Breaking Changes / Backwards Compatibility

Reverts https://github.com/formio/bootstrap/commit/3dde49ae769c569d9dec5e0a2126ab47359717ab#diff-d4f4129fd92b63c9446af2cf9a7d3d15b45cfbfc8b7adb61b131e5c8c1227bdf

## Dependencies

n/a

## How has this PR been tested?

Manually tested in the portal for Safari, Chrome, Firefox and Brave. 

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
