### PR TITLE
FIO-9751 updated modal edit window for components with hidden tabs

### DIFF
--- a/src/templates/bootstrap4/builderComponent/form.ejs
+++ b/src/templates/bootstrap4/builderComponent/form.ejs
@@ -29,15 +29,17 @@
         >
           <i class="{{ctx.iconClass('save')}}"></i>
         </div>
-        <div
-          role="button"
-          aria-label="Edit json button. Click to edit json of the current component"
-          tabindex="-1"
-          class="btn btn-xxs btn-default component-settings-button component-settings-button-edit-json" 
-          ref="editJson"
-        >
-          <i class="{{ctx.iconClass('wrench')}}"></i>
-        </div>
+        {% if (ctx.editJson !== false) { %}
+          <div
+            role="button"
+            aria-label="Edit json button. Click to edit json of the current component"
+            tabindex="-1"
+            class="btn btn-xxs btn-default component-settings-button component-settings-button-edit-json" 
+            ref="editJson"
+          >
+            <i class="{{ctx.iconClass('wrench')}}"></i>
+          </div>
+        {% } %}
       {% } %}
       <div
         role="button"
@@ -48,7 +50,7 @@
       >
         <i class="{{ctx.iconClass('move')}}"></i>
       </div>
-      {% if (!(ctx.design && ctx.childComponent.type === 'reviewpage')) { %}
+      {% if (!(ctx.design && ctx.childComponent.type === 'reviewpage') && ctx.editComponent) { %}
         <div
           role="button"
           aria-label="Edit button. Click to open component settings modal window"

--- a/src/templates/bootstrap5/builderComponent/form.ejs
+++ b/src/templates/bootstrap5/builderComponent/form.ejs
@@ -29,15 +29,17 @@
         >
           <i class="{{ctx.iconClass('save')}}"></i>
         </div>
-        <div
-          role="button"
-          aria-label="Edit json button. Click to edit json of the current component"
-          tabindex="-1"
-          class="btn btn-xxs btn-default component-settings-button component-settings-button-edit-json" 
-          ref="editJson"
-        >
-          <i class="{{ctx.iconClass('wrench')}}"></i>
-        </div>
+        {% if (ctx.editJson !== false) { %}
+          <div
+            role="button"
+            aria-label="Edit json button. Click to edit json of the current component"
+            tabindex="-1"
+            class="btn btn-xxs btn-default component-settings-button component-settings-button-edit-json" 
+            ref="editJson"
+          >
+            <i class="{{ctx.iconClass('wrench')}}"></i>
+          </div>
+        {% } %}
       {% } %}
       <div
         role="button"
@@ -48,7 +50,7 @@
       >
         <i class="{{ctx.iconClass('move')}}"></i>
       </div>
-      {% if (!(ctx.design && ctx.childComponent.type === 'reviewpage')) { %}
+      {% if (!(ctx.design && ctx.childComponent.type === 'reviewpage') && ctx.editComponent) { %}
         <div
           role="button"
           aria-label="Edit button. Click to open component settings modal window"


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9751

## Description

*EditComponent button is hidden for components  that do not have available tabs (for example, Data, Display, etc.). Edit json button also is hidden for all components in the formBuilder using the EFB module.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*https://github.com/formio/formio.js/pull/6024*

## How has this PR been tested?

*locally, using builder configurator and demo app*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
