### PR TITLE
FIO-9761: fixed an issue where fontawesome icons do not appear

### DIFF
--- a/src/templates/bootstrap5/iconClass.ts
+++ b/src/templates/bootstrap5/iconClass.ts
@@ -164,5 +164,5 @@ export default (iconset, name, spinning) => {
             biName = 'arrow-clockwise';
             break;
     }
-    return spinning ? 'spinner-border spinner-border-sm' : `fa fa-${name} bi bi-${biName}`;
+    return spinning ? 'spinner-border spinner-border-sm' : `${iconset} ${iconset}-${name}`;
 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9761

## Description

**What changed?**

Do not use bi and fa icon classes together because they override styles for each other and icons do not display at all.

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
