### PR TITLE
FIO-10065: changed name to biname when using bootstrap icons

### DIFF
--- a/src/templates/bootstrap5/iconClass.spec.ts
+++ b/src/templates/bootstrap5/iconClass.spec.ts
@@ -1,0 +1,8 @@
+import iconClass from './iconClass';
+import {expect} from 'chai';
+describe('iconClass', () => {
+    it('should output bootstrap icon classes if iconset is bi', () => {
+        const classOutput = iconClass('bi', 'remove', false);
+        expect(classOutput).to.equal('bi bi-trash')
+    });
+});

--- a/src/templates/bootstrap5/iconClass.ts
+++ b/src/templates/bootstrap5/iconClass.ts
@@ -1,4 +1,6 @@
-export default (iconset, name, spinning) => {
+type iconset = 'bi' | 'fa';
+
+export default (iconset: iconset, name: string, spinning: boolean) => {
     let biName = name;
     switch (name) {
         case 'cog':
@@ -164,5 +166,5 @@ export default (iconset, name, spinning) => {
             biName = 'arrow-clockwise';
             break;
     }
-    return spinning ? 'spinner-border spinner-border-sm' : `${iconset} ${iconset}-${name}`;
+    return spinning ? 'spinner-border spinner-border-sm' : `${iconset} ${iconset}-${iconset === 'bi' ? biName : name}`;
 };

--- a/src/test.spec.ts
+++ b/src/test.spec.ts
@@ -1,6 +1,6 @@
 describe('First Test', () => {
   it('Runs tests', (done) => {
     done();
-  })
+  });
 });
 


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10065

## Description

**What changed?**

When using bootstrap icons we need to use the biName

**Why have you chosen this solution?**

By just having name you will be using incorrect icons for bootstrap icons

## Breaking Changes / Backwards Compatibility

N/A

## Dependencies

N/A

## How has this PR been tested?

automated test and manually

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [x] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
