### PR TITLE
FIO-10060: Fixes an issue where some bootstrap icons are not displayed

### DIFF
--- a/src/templates/bootstrap5/iconClass.ts
+++ b/src/templates/bootstrap5/iconClass.ts
@@ -164,5 +164,5 @@ export default (iconset, name, spinning) => {
             biName = 'arrow-clockwise';
             break;
     }
-    return spinning ? 'spinner-border spinner-border-sm' : `${iconset} ${iconset}-${name}`;
+    return spinning ? 'spinner-border spinner-border-sm' : `${iconset} ${iconset}-${biName}`;
 };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10060

## Description

Seems like the new variable 'biName' was not used when return the final icon class value, so some icons that do have a name different from the key passed were not displayed

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
