### PR TITLE
FIO-10217 fixed the display of interpolated values in BuilderMode

### DIFF
--- a/src/templates/bootstrap4/html/form.ejs
+++ b/src/templates/bootstrap4/html/form.ejs
@@ -2,4 +2,4 @@
   {% ctx.attrs.forEach(function(attr) { %}
     {{attr.attr}}="{{attr.value}}"
   {% }) %}
->{{ctx.t(ctx.content)}}{% if (!ctx.singleTags || ctx.singleTags.indexOf(ctx.tag) === -1) { %}</{{ctx.tag}}>{% } %}
+>{{ ctx.builder ? ctx.content : ctx.t(ctx.content) }}{% if (!ctx.singleTags || ctx.singleTags.indexOf(ctx.tag) === -1) { %}</{{ctx.tag}}>{% } %}

--- a/src/templates/bootstrap5/html/form.ejs
+++ b/src/templates/bootstrap5/html/form.ejs
@@ -2,4 +2,4 @@
   {% ctx.attrs.forEach(function(attr) { %}
     {{attr.attr}}="{{attr.value}}"
   {% }) %}
->{{ctx.t(ctx.content)}}{% if (!ctx.singleTags || ctx.singleTags.indexOf(ctx.tag) === -1) { %}</{{ctx.tag}}>{% } %}
+>{{ ctx.builder ? ctx.content : ctx.t(ctx.content) }}{% if (!ctx.singleTags || ctx.singleTags.indexOf(ctx.tag) === -1) { %}</{{ctx.tag}}>{% } %}


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-10217

## Description

*Previously, for the Content and HTML components, on the Edit page, all interpolated values were displayed as `undefined`. This was due to the fact that the `ctx.t` method was used when rendering these components, which calls the `interpolateString` method. However, in the Builder mode, there should be no interpolation for the Content and HTML components, but the original content string should be displayed. Therefore, this issue was fixed by adding the condition to the html template.*

## Breaking Changes / Backwards Compatibility

*n/a*

## Dependencies

*n/a*

## How has this PR been tested?

*locally*

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [x] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
