### PR TITLE
FIO-9245: Remove bootstrap column class from data grid template

### DIFF
--- a/src/templates/bootstrap4/datagrid/form.ejs
+++ b/src/templates/bootstrap4/datagrid/form.ejs
@@ -56,7 +56,7 @@
         </td>
         {% } %}
         {% if (ctx.canAddColumn) { %}
-        <td ref="{{ctx.key}}-container" class="col-md-3">
+        <td ref="{{ctx.key}}-container">
           {{ctx.placeholder}}
         </td>
         {% } %}

--- a/src/templates/bootstrap5/datagrid/form.ejs
+++ b/src/templates/bootstrap5/datagrid/form.ejs
@@ -56,7 +56,7 @@
         </td>
         {% } %}
         {% if (ctx.canAddColumn) { %}
-        <td ref="{{ctx.key}}-container" class="col-md-3">
+        <td ref="{{ctx.key}}-container">
           {{ctx.placeholder}}
         </td>
         {% } %}


### PR DESCRIPTION
  - On Safari, it causes the components to the left to be squashed
  - Removing it gives it the behavior it should have on Safari and other browsers

## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-9245

## Description

**What changed?**

Remove unneeded bootstrap column css class that causes components in a data grid to compress on the left side on Safari when viewing the edit tab in the developer portal. 

**Why have you chosen this solution?**

It was the simplest.

## Breaking Changes / Backwards Compatibility

n/a

## Dependencies

n/a

## How has this PR been tested?

Manually. It's a simple css change. 

Here's the change across safari, chrome and brave.

https://github.com/user-attachments/assets/98490801-ed6e-4f09-a5e0-fd9be3c6703f

And firefox:
<img width="1920" height="786" alt="Screenshot 2025-07-14 at 5 39 39 PM" src="https://github.com/user-attachments/assets/573ad594-0deb-4b3a-915b-fea6532f314a" />

## Checklist:

- [x] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
